### PR TITLE
Add basic CORS support by adding a default response header.

### DIFF
--- a/lib/scheme.js
+++ b/lib/scheme.js
@@ -9,8 +9,19 @@ var parse = require('url').parse;
 var qs = require('querystring');
 var http = require('http');
 var headers = {
+    'Access-Control-Allow-Origin': '*',
     'Content-Type': 'text/plain'
 };
+
+function mix(reciever, sender) {
+    Object.keys(sender).forEach(function (key) {
+        if (!reciever.hasOwnProperty(key)) {
+            reciever[key] = sender[key];
+        }
+    });
+
+    return reciever;
+}
 
 exports.headers = headers;
 
@@ -29,7 +40,7 @@ exports.status = function (code, res) {
 exports.get = function (req, res) {
     var p = parse(req.url),
         code = ((req.method === 'GET' || req.method === 'HEAD' || req.method === 'OPTIONS') ? 200 : 403);
-    
+
     res.writeHead(code, headers);
     res.end(p.query || '');
 };
@@ -108,14 +119,14 @@ exports.delay = function (req, res) {
 exports.json = function (req, res) {
     var p = parse(req.url),
         json = (p.query ? JSON.stringify(qs.parse(p.query)) : '{ "echo": true }');
-    
+
     if (req.body) {
         json = JSON.stringify(req.body);
     }
 
-    res.writeHead(200, {
-        'Content-type': 'application/json'
-    });
+    res.writeHead(200, mix({
+        'Content-Type': 'application/json'
+    }, headers));
     res.end(json);
 };
 
@@ -152,9 +163,8 @@ exports.jsonp = function (req, res) {
         json = callback + '(' + JSON.stringify(content) + ');';
     }
 
-
-    res.writeHead(code, {
-        'Content-type': 'application/json'
-    });
+    res.writeHead(code, mix({
+        'Content-Type': 'application/json'
+    }, headers));
     res.end(json);
 };


### PR DESCRIPTION
This adds `"Access-Control-Allow-Origin: *"` as a default HTTP response header which enables support for CORS.
