### PR TITLE
Only handle Express.js `req.body` when it is not empty.

### DIFF
--- a/lib/scheme.js
+++ b/lib/scheme.js
@@ -73,7 +73,8 @@ var post = function (method, req, res) {
             }
         };
 
-    if (req.body) { //Express
+
+    if (req.body && Object.keys(req.body).length) { //Express
         gotData = true;
         data = qs.stringify(req.body);
         end();


### PR DESCRIPTION
Improves request body handling to support more than form-param style request bodies.
