### PR TITLE
file route uses __dirname

### DIFF
--- a/lib/echo.js
+++ b/lib/echo.js
@@ -77,23 +77,30 @@ EchoEcho.prototype = {
     handle: function (req) {
         return !!this.validate(req, true);
     },
-    serve: function (req, res) {
+    serve: function (req, res, config) {
         var self = this,
             base = this.validate(req),
             filepath,
             parsed,
             query,
-            data;
+            data,
+            dirroot = __dirname;
+
+        config = config || {};
+
+        if (config.dirroot) {
+            dirroot = config.dirroot;
+        }
 
         if (base && base !== true) {
             if (this.scheme[base]) {
-                query  = parse(req.url).query,
+                query  = parse(req.url).query;
                 parsed = qs.parse(query);
 
                 if (parsed.response) {
                     this.scheme[base](req, res, parsed.response);
                 } else if (parsed.file) {
-                    filepath = path.join(__dirname, parsed.file);
+                    filepath = path.join(dirroot, parsed.file);
                     fs.readFile(filepath, function (err, data) {
                         if (err) {
                             self.scheme.status(404, res);


### PR DESCRIPTION
If you try to use `echo/get/?file=assets/checknet.txt` from yeti (for example), it uses __dirname so the end file is 
`/Users/nicols/git/yui/yeti/node_modules/echoecho/lib/assets/checknet.txt`

Ideally it should use a more relevant directory. I'm not sure whether this should be the process cwd(), or whether it should take an override somewhere...

```
    this.echoecho = new EchoEcho({
        all: true
    });
    if (this.echoecho.handle(path)) {
        this.echoecho.setRoot(pathRoot);
        this.echoecho.serve(server.req, server.res);
    }
```
